### PR TITLE
docs: clarify codex initialization

### DIFF
--- a/src/main/java/elucent/eidolon/codex/CodexChapters.java
+++ b/src/main/java/elucent/eidolon/codex/CodexChapters.java
@@ -39,6 +39,12 @@ public class CodexChapters {
 
     /**
      * Rebuilds the codex contents using data supplied by {@link CodexDataLoader}.
+     * <p>
+     * {@link CodexDataLoader} runs as a resource reload listener and parses all
+     * chapter JSON files before this method is invoked.  Calling {@code init}
+     * therefore clears any previously registered chapters and installs the
+     * freshly loaded, data‑driven chapters into the in‑game categories so the
+     * codex reflects datapack changes.
      */
     public static void init() {
         if (!categories.isEmpty()) {


### PR DESCRIPTION
## Summary
- clarify CodexChapters.init lifecycle and data-driven chapter loading

## Testing
- `./gradlew test` *(fails: cannot find symbol CodexDataLoader.getChapters)*

------
https://chatgpt.com/codex/tasks/task_e_689766165b7c83278ce9f203490b1e9f