### PR TITLE
Use Raven Cloak for fall mitigation

### DIFF
--- a/src/main/java/elucent/eidolon/common/item/curio/RavenCloakItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/RavenCloakItem.java
@@ -23,7 +23,7 @@ public class RavenCloakItem extends EidolonCurio implements IWingsItem {
 
     @SubscribeEvent
     public static void onFall(LivingFallEvent event) {
-        if (CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.GRAVITY_BELT.get()).isPresent()) {
+        if (CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.RAVEN_CLOAK.get()).isPresent()) {
             event.setDistance(event.getDistance() / 4);
         }
     }


### PR DESCRIPTION
## Summary
- swap fall mitigation check to use Raven Cloak

## Testing
- `bash ./gradlew build` *(fails: Unsupported class file major version 65)*

## Log new insights
- Fall event now checks for Raven Cloak instead of Gravity Belt.

## Document past failures
- `./gradlew build` failed: Unsupported class file major version 65.


------
https://chatgpt.com/codex/tasks/task_e_6898602fd1888327b70d14db1489f3c1