### PR TITLE
Refactor Curios lookups to new inventory API

### DIFF
--- a/src/main/java/elucent/eidolon/capability/IPlayerData.java
+++ b/src/main/java/elucent/eidolon/capability/IPlayerData.java
@@ -40,12 +40,15 @@ public interface IPlayerData {
 
     default ItemStack getWingsItem(Player player) {
         ItemStack[] result = new ItemStack[]{ItemStack.EMPTY};
-        CuriosApi.getCuriosHelper().getEquippedCurios(player).ifPresent((h) -> {
-            for (int i = 0; i < h.getSlots(); i ++) {
-                ItemStack s = h.getStackInSlot(i);
-                if (s.getItem() instanceof IWingsItem) {
-                    result[0] = s;
-                    break;
+        CuriosApi.getCuriosInventory(player).resolve().ifPresent(inv -> {
+            for (var handler : inv.getCurios().values()) {
+                var stacks = handler.getStacks();
+                for (int i = 0; i < stacks.getSlots(); i++) {
+                    ItemStack s = stacks.getStackInSlot(i);
+                    if (s.getItem() instanceof IWingsItem) {
+                        result[0] = s;
+                        return;
+                    }
                 }
             }
         });

--- a/src/main/java/elucent/eidolon/common/item/curio/AngelSightItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/AngelSightItem.java
@@ -67,8 +67,11 @@ public class AngelSightItem extends EidolonCurio {
     @SubscribeEvent
     public static void addMode(final EntityJoinLevelEvent event) {
         if (event.getEntity() instanceof Projectile projectile && projectile.getOwner() instanceof Player player) {
-            CuriosApi.getCuriosHelper().findFirstCurio(player, Registry.ANGELS_SIGHT.get()).ifPresent(ring -> {
-                Predicate<Entity> targetMode = switch (ring.stack().getOrCreateTag().getInt("mode")) {
+            CuriosApi.getCuriosInventory(player)
+                .resolve()
+                .flatMap(inv -> inv.findFirstCurio(Registry.ANGELS_SIGHT.get()))
+                .ifPresent(slot -> {
+                Predicate<Entity> targetMode = switch (slot.stack().getOrCreateTag().getInt("mode")) {
                     case 1 -> target -> target instanceof LivingEntity && !(target instanceof Player);
                     case 2 -> target -> target instanceof Enemy;
                     default -> target -> target instanceof LivingEntity;

--- a/src/main/java/elucent/eidolon/common/item/curio/GlassHandItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/GlassHandItem.java
@@ -16,11 +16,17 @@ public class GlassHandItem extends ItemBase {
 
     @SubscribeEvent
     public static void onHurt(LivingHurtEvent event) {
-        if (CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.GLASS_HAND.get()).isPresent()) {
+        if (CuriosApi.getCuriosInventory(event.getEntity())
+            .resolve()
+            .flatMap(inv -> inv.findFirstCurio(Registry.GLASS_HAND.get()))
+            .isPresent()) {
             event.setAmount(event.getAmount() * 5);
         }
         if (event.getSource().getEntity() instanceof LivingEntity living &&
-            CuriosApi.getCuriosHelper().findFirstCurio(living, Registry.GLASS_HAND.get()).isPresent()) {
+            CuriosApi.getCuriosInventory(living)
+                .resolve()
+                .flatMap(inv -> inv.findFirstCurio(Registry.GLASS_HAND.get()))
+                .isPresent()) {
             event.setAmount(event.getAmount() * 2);
         }
     }

--- a/src/main/java/elucent/eidolon/common/item/curio/GravityBeltItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/GravityBeltItem.java
@@ -25,7 +25,10 @@ public class GravityBeltItem extends BasicBeltItem {
 
     @SubscribeEvent
     public static void onFall(LivingFallEvent event) {
-        if (CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.GRAVITY_BELT.get()).isPresent()) {
+        if (CuriosApi.getCuriosInventory(event.getEntity())
+            .resolve()
+            .flatMap(inv -> inv.findFirstCurio(Registry.GRAVITY_BELT.get()))
+            .isPresent()) {
             event.setDistance(event.getDistance() / 4);
         }
     }

--- a/src/main/java/elucent/eidolon/common/item/curio/MindShieldingPlateItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/MindShieldingPlateItem.java
@@ -22,7 +22,10 @@ public class MindShieldingPlateItem extends ItemBase {
 
     @SubscribeEvent
     public static void onPotion(MobEffectEvent.Applicable event) {
-        if (event.getEffectInstance().getEffect() == MobEffects.CONFUSION && CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.MIND_SHIELDING_PLATE.get()).isPresent()) {
+        if (event.getEffectInstance().getEffect() == MobEffects.CONFUSION && CuriosApi.getCuriosInventory(event.getEntity())
+            .resolve()
+            .flatMap(inv -> inv.findFirstCurio(Registry.MIND_SHIELDING_PLATE.get()))
+            .isPresent()) {
             event.setResult(Event.Result.DENY);
         }
     }
@@ -39,7 +42,10 @@ public class MindShieldingPlateItem extends ItemBase {
 
     @SubscribeEvent
     public static void onDropXP(LivingExperienceDropEvent event) {
-        if (event.getEntity() instanceof Player player && CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.MIND_SHIELDING_PLATE.get()).isPresent()) {
+        if (event.getEntity() instanceof Player player && CuriosApi.getCuriosInventory(event.getEntity())
+            .resolve()
+            .flatMap(inv -> inv.findFirstCurio(Registry.MIND_SHIELDING_PLATE.get()))
+            .isPresent()) {
             player.experienceLevel |= LEVEL_FLAG;
             event.setCanceled(true);
         }

--- a/src/main/java/elucent/eidolon/common/item/curio/RavenCloakItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/RavenCloakItem.java
@@ -23,7 +23,10 @@ public class RavenCloakItem extends EidolonCurio implements IWingsItem {
 
     @SubscribeEvent
     public static void onFall(LivingFallEvent event) {
-        if (CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.GRAVITY_BELT.get()).isPresent()) {
+        if (CuriosApi.getCuriosInventory(event.getEntity())
+            .resolve()
+            .flatMap(inv -> inv.findFirstCurio(Registry.GRAVITY_BELT.get()))
+            .isPresent()) {
             event.setDistance(event.getDistance() / 4);
         }
     }

--- a/src/main/java/elucent/eidolon/common/item/curio/ResoluteBeltItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/ResoluteBeltItem.java
@@ -32,7 +32,10 @@ public class ResoluteBeltItem extends EidolonCurio {
 
     @SubscribeEvent
     public static void onHurt(LivingHurtEvent event) {
-        if (event.getSource().getEntity() instanceof LivingEntity entity && CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.RESOLUTE_BELT.get()).isPresent()) {
+        if (event.getSource().getEntity() instanceof LivingEntity entity && CuriosApi.getCuriosInventory(event.getEntity())
+            .resolve()
+            .flatMap(inv -> inv.findFirstCurio(Registry.RESOLUTE_BELT.get()))
+            .isPresent()) {
             Vec3 diff = event.getEntity().position().subtract(entity.position()).multiply(1, 0, 1).normalize();
             entity.knockback(0.8f, diff.x, diff.z);
             if (!entity.level.isClientSide)

--- a/src/main/java/elucent/eidolon/common/item/curio/SoulboneAmuletItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/SoulboneAmuletItem.java
@@ -29,7 +29,10 @@ public class SoulboneAmuletItem extends ItemBase implements ICurioItem {
     @SubscribeEvent
     public static void onKill(LivingDeathEvent event) {
         if (event.getSource().getEntity() instanceof LivingEntity e) {
-            if (CuriosApi.getCuriosHelper().findFirstCurio(e, Registry.SOULBONE_AMULET.get()).isPresent()) {
+            if (CuriosApi.getCuriosInventory(e)
+                .resolve()
+                .flatMap(inv -> inv.findFirstCurio(Registry.SOULBONE_AMULET.get()))
+                .isPresent()) {
                 e.getCapability(ISoul.INSTANCE).ifPresent((cap) -> {
                     cap.setMaxEtherealHealth(Math.max(Math.min(ISoul.getPersistentHealth(e), cap.getMaxEtherealHealth()), 2 * Mth.floor((cap.getEtherealHealth() + 3) / 2)));
                     cap.setEtherealHealth(cap.getEtherealHealth() + 2);

--- a/src/main/java/elucent/eidolon/common/item/curio/TerminusMirrorItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/TerminusMirrorItem.java
@@ -20,7 +20,10 @@ public class TerminusMirrorItem extends EidolonCurio {
     @SubscribeEvent
     public static void onDamage(LivingAttackEvent event) {
         if (event.getEntity() instanceof Player) {
-            CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.TERMINUS_MIRROR.get()).ifPresent((slots) -> {
+            CuriosApi.getCuriosInventory(event.getEntity())
+                .resolve()
+                .flatMap(inv -> inv.findFirstCurio(Registry.TERMINUS_MIRROR.get()))
+                .ifPresent(slots -> {
                 ItemStack stack = slots.stack();
                 if (event.getSource().getDirectEntity() instanceof Projectile) {
                     event.setCanceled(true);

--- a/src/main/java/elucent/eidolon/common/item/curio/VoidAmuletItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/VoidAmuletItem.java
@@ -42,7 +42,10 @@ public class VoidAmuletItem extends EidolonCurio {
     @SubscribeEvent
     public static void onDamage(LivingAttackEvent event) {
         if (event.getEntity() instanceof Player player) {
-            CuriosApi.getCuriosHelper().findFirstCurio(player, Registry.VOID_AMULET.get()).ifPresent((stack) -> {
+            CuriosApi.getCuriosInventory(player)
+                .resolve()
+                .flatMap(inv -> inv.findFirstCurio(Registry.VOID_AMULET.get()))
+                .ifPresent(stack -> {
                 if (getCooldown(stack.stack()) == 0) {
                     if (event.getSource().getDirectEntity() instanceof Projectile
                         || event.getSource().getDirectEntity() instanceof SpellProjectileEntity) {

--- a/src/main/java/elucent/eidolon/common/item/curio/WardedMailItem.java
+++ b/src/main/java/elucent/eidolon/common/item/curio/WardedMailItem.java
@@ -18,7 +18,10 @@ public class WardedMailItem extends ItemBase {
     @SubscribeEvent
     public static void onDamage(LivingAttackEvent event) {
         if (event.getSource().is(DamageTypeTags.WITCH_RESISTANT_TO)) {
-            CuriosApi.getCuriosHelper().findFirstCurio(event.getEntity(), Registry.WARDED_MAIL.get()).ifPresent((slots) -> {
+            CuriosApi.getCuriosInventory(event.getEntity())
+                .resolve()
+                .flatMap(inv -> inv.findFirstCurio(Registry.WARDED_MAIL.get()))
+                .ifPresent(slots -> {
 
                 event.setCanceled(true);
                 event.getEntity().hurt(new DamageSource(event.getEntity().damageSources().generic().typeHolder()), event.getAmount());


### PR DESCRIPTION
## Summary
- replace deprecated `getCuriosHelper().findFirstCurio` calls with `CuriosApi.getCuriosInventory(...).resolve().flatMap(...).ifPresent(...)`
- update `IPlayerData.getWingsItem` to scan the Curios inventory for wing items

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH ./gradlew build` *(fails: cannot find symbol CodexDataLoader.getChapters)*

------
https://chatgpt.com/codex/tasks/task_e_6898602f2d5483278654c6293111f6b1